### PR TITLE
Added new API to pass user arrays to scripting.

### DIFF
--- a/Libs/Nodes/include/Visus/ScriptingNode.h
+++ b/Libs/Nodes/include/Visus/ScriptingNode.h
@@ -75,6 +75,19 @@ public:
     endUpdate();
   }
 
+  void addUserInput(String key, SharedPtr<Array> value) {
+    try {
+      ScopedAcquireGil acquire_gil;
+      engine->setModuleAttr(key, *value);
+    }
+    catch (std::exception ex)
+    {
+      ScopedAcquireGil acquire_gil;
+      engine->printMessage(ex.what());
+      return;
+    }
+  }
+
   //clearPresets
   void clearPresets();
 


### PR DESCRIPTION
Added new API to pass user arrays to scripting.

Usage

def addScript():
a=numpy.random.randn(100,100,100)
b=numpy.random.randn(100,100,100)
c=2
scripting_node=ScriptingNode.castFrom(viewer.findNodeByName("Scripting"))
script="import numpy as np\r" 
"output="+str(c)+"*a+b"
scripting_node.addUserInput("a", Array.fromNumPy(a))
scripting_node.addUserInput("b", Array.fromNumPy(b))
scripting_node.setCode(script)
viewer.refreshData(scripting_node)