### PR TITLE
Ensured Dockerfile.anaconda creates a working image, added a 3d dataset to default visus.config used in all Docker deployments

### DIFF
--- a/Docker/Dockerfile.anaconda
+++ b/Docker/Dockerfile.anaconda
@@ -15,13 +15,18 @@ RUN apt-get update \
   && apt-get install -y apache2
 
 # install and configure OpenVisus
-RUN conda install -y -c visus openvisus
-RUN ln -s $(python3 -m OpenVisus) ${VISUS_HOME}
-RUN echo "export VISUS_HOME=${VISUS_HOME}" >> ~/.bashrc 
+RUN pip install OpenVisus==1.3.8  # 1.3.8 (in PyPI) was the last working version to include mod_visus
+RUN ln -s $(python3 -c "import os, OpenVisus; print(os.path.dirname(OpenVisus.__file__))") ${VISUS_HOME}
+RUN echo "export VISUS_HOME=${VISUS_HOME}" >> ~/.bashrc
+RUN ln -s ${VISUS_HOME}/bin/visus ${CONDA_PREFIX}/bin/visus \
+ && ln -s ${VISUS_HOME}/bin/visus ${CONDA_PREFIX}/bin/visus.sh
 
 # fix rpaths
-RUN conda install -y patchelf 
-RUN ${CONDA_PREFIX}/bin/patchelf --set-rpath '$ORIGIN:/opt/conda/lib' ${VISUS_HOME}/bin/libmod_visus.so
+# - still needed for 1.3.8, but latest 1.3.56 (in anaconda.org) doesn't need to patch visus executable
+# - when mod_visus gets added it will hopefully also not need patching and this can be removed
+RUN conda install -y patchelf \
+  && ${CONDA_PREFIX}/bin/patchelf --set-rpath '$ORIGIN:/opt/conda/lib' ${VISUS_HOME}/bin/visus \
+  && ${CONDA_PREFIX}/bin/patchelf --set-rpath '$ORIGIN:/opt/conda/lib' ${VISUS_HOME}/bin/libmod_visus.so
 
 # install webviewer
 ADD https://api.github.com/repos/sci-visus/OpenVisusJS/git/refs/heads/master version.json
@@ -31,6 +36,7 @@ RUN git clone -bmaster https://github.com/sci-visus/OpenVisusJS.git ${VISUS_HOME
 COPY resources/shared/000-default.conf /etc/apache2/sites-enabled
 COPY resources/shared/.htpasswd    ${VISUS_HOME}
 COPY resources/shared/visus.config ${VISUS_HOME}
+RUN chmod a+rw ${VISUS_HOME}/visus.config
 COPY resources/shared/httpd-foreground.sh /usr/local/bin
 RUN echo "LoadModule visus_module ${VISUS_HOME}/bin/libmod_visus.so" > /etc/apache2/mods-available/visus.load \
   && a2enmod headers \
@@ -40,4 +46,3 @@ RUN echo "LoadModule visus_module ${VISUS_HOME}/bin/libmod_visus.so" > /etc/apac
 # run
 EXPOSE 80
 CMD ["/usr/local/bin/httpd-foreground.sh"]
-

--- a/Docker/resources/shared/visus.config
+++ b/Docker/resources/shared/visus.config
@@ -7,6 +7,7 @@
   <datasets>
     <dataset name="BlueMarbleDay"   url="http://atlantis.sci.utah.edu/mod_visus?dataset=BlueMarble&amp;compression=zip" permissions="public" />
     <dataset name="BlueMarbleNight" url="http://atlantis.sci.utah.edu/mod_visus?dataset=BlueMarbleNight&amp;compression=zip" permissions="public" />
+    <dataset name="2kbit1" url="http://molniya.sci.utah.edu/mod_visus?dataset=2kbit1&amp;compression=zip" permissions="public" />
   </datasets>
 
 </visus>


### PR DESCRIPTION
note: for the 3d dataset, used molniya rather than atlantis because for some reason the webviewer isn't working with current server on atlantis.

Here are the details regarding making a working Dockerfile.anaconda:
- Hardcoded 1.3.8 version since that's the last one that worked and included mod_visus.

- uses pip install instead of conda install since only the pip (PyPI) version contains mod_visus (the visus exe in the conda version also segfaults)

- fix symlink (back to the way it was done before dd13f40):
(base) root@a03c4c7eeee3:/# python3 -m OpenVisus
Traceback (most recent call last):
  File "/opt/conda/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/conda/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/opt/conda/lib/python3.7/site-packages/OpenVisus/__main__.py", line 4, in <module>
    Deploy.Main()
  File "/opt/conda/lib/python3.7/site-packages/OpenVisus/./Deploy.py", line 593, in Main
    action=sys.argv[1]
IndexError: list index out of range
(base) root@a03c4c7eeee3:/# python3 -c "import os, OpenVisus; print(os.path.dirname(OpenVisus.__file__))"
/opt/conda/lib/python3.7/site-packages/OpenVisus

- re-add symlinks so visus executable is accessible in default conda path:
ln -s ${VISUS_HOME}/bin/visus ${CONDA_PREFIX}/bin/visus
ln -s ${VISUS_HOME}/bin/visus ${CONDA_PREFIX}/bin/visus.sh
