### PR TITLE
OSPRay 2.0.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ if (VISUS_GUI)
 endif()
 
 if (VISUS_OSPRAY)
-	find_package(ospray REQUIRED)
+	find_package(ospray 2.0 REQUIRED)
 endif()
 
 

--- a/Libs/AppKit/src/Viewer.cpp
+++ b/Libs/AppKit/src/Viewer.cpp
@@ -2548,7 +2548,12 @@ Node* Viewer::addRender(String uuid, Node* parent, String palette)
     StringTree("RemoveNode", "uuid", uuid));
   {
     //render
-    auto render_node = new RenderArrayNode();
+    Node *render_node = nullptr;
+    if (VisusModule::getModuleConfig()->readString("Configuration/VisusViewer/DefaultRenderNode/value") == "ospray") {
+      render_node = new OSPRayRenderNode();
+    } else {
+      render_node = new RenderArrayNode();
+    }
     ret = render_node;
     render_node->setUUID(uuid);
     render_node->setName("RenderArray");

--- a/Libs/Db/src/IdxMultipleDataset.cpp
+++ b/Libs/Db/src/IdxMultipleDataset.cpp
@@ -1031,7 +1031,7 @@ String IdxMultipleDataset::getInputName(String dataset_name, String fieldname)
 
   return out.str();
 #else
-  return FormatString() << "input." << dataset_name << "." << fieldname;
+  return "input." + dataset_name + "." + fieldname;
 #endif
 };
 

--- a/Libs/GuiNodes/CMakeLists.txt
+++ b/Libs/GuiNodes/CMakeLists.txt
@@ -3,7 +3,6 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
 if (VISUS_OSPRAY)
-	include_directories(${OSPRAY_INCLUDE_DIR})
 	target_compile_definitions(VisusKernel PUBLIC -DVISUS_OSPRAY=1)
 endif()
 
@@ -13,7 +12,7 @@ AddLibrary(VisusGuiNodes SHARED ${Sources})
 target_link_libraries(VisusGuiNodes PUBLIC VisusGui VisusDataflow)
 
 if (VISUS_OSPRAY)
-	target_link_libraries(VisusGuiNodes PUBLIC ${OSPRAY_LIBRARIES})
+	target_link_libraries(VisusGuiNodes PUBLIC ospray::ospray)
 endif()
 
 if (VISUS_PYTHON)


### PR DESCRIPTION
Update to OSPRay 2.0

A few other notes you may want to check are ok @scrgiorgio 

- ospray's package cmake config needs cmake 3+ now, since it exports targets https://github.com/sci-visus/OpenVisus/compare/ospray-2.0.x#diff-2cfabfb27fb4654257e6d14e89c5e15fR15 it will work as is if people have cmake 3+, but will probbaly give an error on cmake 2.8. We could just have cmake 3+ be required for using ospray
- I added back in the check for the config file render node being ospray: https://github.com/sci-visus/OpenVisus/compare/ospray-2.0.x#diff-b40d064b89b35233ce0037f56b583175R2552 if that looks fine
- ~~I put a temporary workaround here https://github.com/sci-visus/OpenVisus/compare/ospray-2.0.x#diff-ba460bfb520c018fc4c86710e82a8684R1034 for https://github.com/sci-visus/OpenVisus/issues/95~~ I merged and took the fix you put in master