### PR TITLE
Fix error handling when no ospray support compiled in

### DIFF
--- a/Libs/GuiNodes/CMakeLists.txt
+++ b/Libs/GuiNodes/CMakeLists.txt
@@ -2,16 +2,13 @@
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-if (VISUS_OSPRAY)
-	target_compile_definitions(VisusKernel PUBLIC -DVISUS_OSPRAY=1)
-endif()
-
 file(GLOB Sources include/Visus/*.h src/*.cpp resources/*.glsl resources/*.qrc)
 source_group("" FILES ${Sources})
 AddLibrary(VisusGuiNodes SHARED ${Sources})
 target_link_libraries(VisusGuiNodes PUBLIC VisusGui VisusDataflow)
 
 if (VISUS_OSPRAY)
+	target_compile_definitions(VisusGuiNodes PUBLIC -DVISUS_OSPRAY=1)
 	target_link_libraries(VisusGuiNodes PUBLIC ospray::ospray)
 endif()
 

--- a/Libs/GuiNodes/src/OSPRayRenderNode.cpp
+++ b/Libs/GuiNodes/src/OSPRayRenderNode.cpp
@@ -356,6 +356,9 @@ OSPRayRenderNode::OSPRayRenderNode()
 
   addInputPort("array");
   addInputPort("palette");
+#ifndef VISUS_OSPRAY
+  ThrowException("Requested to use OSPRayRenderNode, but OSPRay support was not compiled in!");
+#endif
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
If no OSPRay support was built in we'll now throw an exception when creating the OSPRayRenderNode