### PR TITLE
missing search for ospcommon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ endif()
 
 if (VISUS_OSPRAY)
 	find_package(ospray 2.0 REQUIRED)
+	find_package(ospcommon REQUIRED)
 endif()
 
 

--- a/Libs/GuiNodes/CMakeLists.txt
+++ b/Libs/GuiNodes/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(VisusGuiNodes PUBLIC VisusGui VisusDataflow)
 
 if (VISUS_OSPRAY)
 	target_compile_definitions(VisusGuiNodes PUBLIC -DVISUS_OSPRAY=1)
-	target_link_libraries(VisusGuiNodes PUBLIC ospray::ospray)
+	target_link_libraries(VisusGuiNodes PUBLIC ospray::ospray ospcommon::ospcommon)
 endif()
 
 if (VISUS_PYTHON)


### PR DESCRIPTION
Sorry @scrgiorgio , one more small fix. When building against an OSPRay binary install we also need to find the ospcommon package (https://github.com/ospray/ospcommon)