### PR TITLE
Progressive accumulation and improved lighting for OSPRay rendering

### DIFF
--- a/Libs/GuiNodes/src/OSPRayRenderNode.cpp
+++ b/Libs/GuiNodes/src/OSPRayRenderNode.cpp
@@ -74,10 +74,12 @@ public:
 
     // create and setup an ambient light
     cpp::Light ambient_light("ambient");
+    ambient_light.setParam("intensity", 0.25f);
     ambient_light.commit();
 
     cpp::Light directional_light("distant");
-    directional_light.setParam("direction", math::vec3f(0.5f, -1.f, 0.25f));
+    directional_light.setParam("direction", math::vec3f(0.5f, 1.f, 0.25f));
+    directional_light.setParam("intensity", 10.f);
     directional_light.commit();
     std::vector<cpp::Light> lights = {ambient_light, directional_light};
     world.setParam("light", cpp::Data(lights));
@@ -87,6 +89,9 @@ public:
     // regular render node (which doesn't seem to do srgb?)
     const math::vec3f bgColor(0.021219f, 0.0423114f, 0.093059f);
     renderer.setParam("backgroundColor", bgColor);
+    renderer.setParam("varianceThreshold", varianceThreshold);
+    renderer.setParam("maxPathLength", int(8));
+    renderer.setParam("volumeSamplingRate", 0.25f);
     renderer.commit();
   }
 
@@ -109,7 +114,7 @@ public:
 
     sceneChanged = true;
 
-    const size_t npaletteSamples = 256;
+    const size_t npaletteSamples = 128;
     std::vector<math::vec3f> tfnColors(npaletteSamples, math::vec3f(0.f));
     std::vector<float> tfnOpacities(npaletteSamples, 0.f);
 
@@ -221,8 +226,10 @@ public:
     if (viewport.width != imgDims[0] || viewport.height != imgDims[1]) 
     {
       sceneChanged = true;
+
       imgDims[0] = viewport.width;
       imgDims[1] = viewport.height;
+
       camera.setParam("aspect", imgDims[0] / static_cast<float>(imgDims[1]));
       camera.commit();
 
@@ -290,9 +297,9 @@ private:
   Point4d prevUpDir = Point4d(0.f, 0.f, 0.f, 0.f);
   bool sceneChanged = true;
 
-  float varianceThreshold = 2.f;
+  float varianceThreshold = 15.f;
 
-  std::array<int, 2>  imgDims = { -1,-1 };
+  std::array<int, 2> imgDims = { -1,-1 };
 
   //dtypeToOSPDtype
   static OSPDataType dtypeToOSPDtype(const DType& dtype) {
@@ -432,7 +439,6 @@ bool OSPRayRenderNode::processInput()
   this->data   = *data;
   this->palette = palette;
 
-  PrintInfo("got array","data",this->data.dims);
   return true;
 }
 

--- a/Libs/GuiNodes/src/OSPRayRenderNode.cpp
+++ b/Libs/GuiNodes/src/OSPRayRenderNode.cpp
@@ -225,6 +225,8 @@ public:
 
     if (viewport.width != imgDims[0] || viewport.height != imgDims[1]) 
     {
+      // On windows it seems like the ref-counting doesn't quite work and we leak?
+      ospRelease(framebuffer.handle());
       sceneChanged = true;
 
       imgDims[0] = viewport.width;

--- a/Libs/GuiNodes/src/OSPRayRenderNode.cpp
+++ b/Libs/GuiNodes/src/OSPRayRenderNode.cpp
@@ -107,6 +107,8 @@ public:
     if (palette->functions.size() != 4) 
       PrintInfo("WARNING: OSPRay palettes must be RGBA!");
 
+    sceneChanged = true;
+
     const size_t npaletteSamples = 256;
     std::vector<math::vec3f> tfnColors(npaletteSamples, math::vec3f(0.f));
     std::vector<float> tfnOpacities(npaletteSamples, 0.f);
@@ -202,30 +204,40 @@ public:
     const auto eyeDir = invCamera * Point4d(0.f, 0.f, -1.f, 0.f);
     const auto upDir  = invCamera * Point4d(0.f, 1.f, 0.f, 0.f);
 
-    camera.setParam("position", math::vec3f(eyePos.x, eyePos.y, eyePos.z));
-    camera.setParam("direction", math::vec3f(eyeDir.x, eyeDir.y, eyeDir.z));
-    camera.setParam("up", math::vec3f(upDir.x, upDir.y, upDir.z));
+    if (eyePos != prevEyePos || eyeDir != prevEyeDir || upDir != prevUpDir) {
+      camera.setParam("position", math::vec3f(eyePos.x, eyePos.y, eyePos.z));
+      camera.setParam("direction", math::vec3f(eyeDir.x, eyeDir.y, eyeDir.z));
+      camera.setParam("up", math::vec3f(upDir.x, upDir.y, upDir.z));
+      camera.commit();
+      sceneChanged = true;
+    }
+    prevEyePos = eyePos;
+    prevEyeDir = eyeDir;
+    prevUpDir = upDir;
 
     // Get window dimensions for framebuffer
     const auto viewport = gl.getViewport();
 
     if (viewport.width != imgDims[0] || viewport.height != imgDims[1]) 
     {
+      sceneChanged = true;
       imgDims[0] = viewport.width;
       imgDims[1] = viewport.height;
       camera.setParam("aspect", imgDims[0] / static_cast<float>(imgDims[1]));
+      camera.commit();
 
       framebuffer = cpp::FrameBuffer(math::vec2i(imgDims[0], imgDims[1]), OSP_FB_SRGBA,
-              OSP_FB_COLOR | OSP_FB_ACCUM);
+              OSP_FB_COLOR | OSP_FB_ACCUM | OSP_FB_VARIANCE);
     }
-    camera.commit();
 
-    framebuffer.clear();
+    if (sceneChanged) {
+        sceneChanged = false;
+        framebuffer.clear();
+    }
 
     framebuffer.renderFrame(renderer, camera, world);
 
     uint32_t *fb = (uint32_t*)framebuffer.map(OSP_FB_COLOR);
-
     // Blit the rendered framebuffer from OSPRay
     {
       auto fbArray = Array(imgDims[0], imgDims[1], DTypes::UINT8_RGBA,HeapMemory::createUnmanaged(fb, imgDims[0] * imgDims[1] * 4));
@@ -252,8 +264,11 @@ public:
       gl.popProjection();
       gl.popModelview();
     }
-
     framebuffer.unmap(fb);
+
+    if (ospGetVariance(framebuffer.handle()) > varianceThreshold) {
+        gl.postRedisplay();
+    }
   }
 
 private:
@@ -269,6 +284,13 @@ private:
   ospray::cpp::Camera camera;
   ospray::cpp::Renderer renderer;
   ospray::cpp::FrameBuffer framebuffer;
+
+  Point4d prevEyePos = Point4d(0.f, 0.f, 0.f, 0.f);
+  Point4d prevEyeDir = Point4d(0.f, 0.f, 0.f, 0.f);
+  Point4d prevUpDir = Point4d(0.f, 0.f, 0.f, 0.f);
+  bool sceneChanged = true;
+
+  float varianceThreshold = 2.f;
 
   std::array<int, 2>  imgDims = { -1,-1 };
 


### PR DESCRIPTION
This now uses OSPRay's variance tracking to determine when we can stop rendering the image (i.e., it's converged to good quality). I also improved the lighting setup for the path tracer so it looks a bit nicer. In the future we could look at auto-placing the lights or adding some UI