### PR TITLE
Add `conda conda` fix

### DIFF
--- a/Libs/swig/__main__.py
+++ b/Libs/swig/__main__.py
@@ -115,9 +115,9 @@ def Configure(bUserInstall=False):
 	print("sys.executable",sys.executable,"VISUS_GUI",VISUS_GUI, "QT_VERSION", QT_VERSION, "IS_CONDA", IS_CONDA, "CONDA_PREFIX",CONDA_PREFIX)
 
 	if IS_CONDA:
-		cmd=['conda', 'install', '-y', '-c', 'conda-forge', 'numpy'] 
+		cmd=['install', '-y', '-c', 'conda-forge', 'numpy']
 		if VISUS_GUI:
-			cmd+=["pyqt={QT_MAJOR_VERSION}.{QT_MINOR_VERSION}"]
+			cmd+=[f"pyqt={QT_MAJOR_VERSION}.{QT_MINOR_VERSION}"]
 			if LINUX: cmd+=["libglu"]
 		conda.cli.main(*cmd)
 		print("OPENVISUS WARNING", "if you get errors like:  module compiled against API version 0xc but this version of numpy is 0xa, then execute","conda update -y numpy")

--- a/README.md
+++ b/README.md
@@ -129,6 +129,6 @@ A user would need to start the SOCKS5 proxy connection using a client. This can 
 ssh -D 55051 user@server
 ```
 
-On Windows, you can enable a SOCKS5 proxy by using PuTTY. More information on that can be found [here](https://www.simplified.guide/putty/create-socks-proxy#:~:text=Go%20to%20Connection%20%E2%86%92%20SSH,in%20the%20Source%20port%20field.&text=Make%20sure%20Auto%20and%20Dynamic,Click%20on%20Add%20button.).
+On Windows, you can enable a SOCKS5 proxy by using PuTTY. More information on that can be found [here](https://www.simplified.guide/putty/create-socks-proxy).
 
 Keep in mind that the port you open the connection with must match the one specified in the visus.config file.


### PR DESCRIPTION
When running the configuration, I used to get an error: `CommandNotFoundError: No command 'conda conda'.`. I believe this is because we are passing a command `conda install ...` into `conda.cli.main` which doesn't understand the `conda` command, only the things that follow it. I modified my local installation to test if the configure script would run, and it does! I am still encountering issues with qt5 though