### PR TITLE
Disable Conda During Configuration

### DIFF
--- a/Libs/swig/__main__.py
+++ b/Libs/swig/__main__.py
@@ -105,7 +105,7 @@ def ShowDeps(all_bins):
 # ////////////////////////////////////////////////
 def Configure(bUserInstall=False):
 	
-	IS_CONDA = os.path.exists(os.path.join(sys.prefix, 'conda-meta', 'history')) # see https://stackoverflow.com/questions/47608532/how-to-detect-from-within-python-whether-packages-are-managed-with-conda
+	IS_CONDA = False # os.path.exists(os.path.join(sys.prefix, 'conda-meta', 'history')) # see https://stackoverflow.com/questions/47608532/how-to-detect-from-within-python-whether-packages-are-managed-with-conda
 	IS_CPYTHON = not IS_CONDA
 	CONDA_PREFIX=os.environ['CONDA_PREFIX'] if IS_CONDA else ""		
 	VISUS_GUI=os.path.isfile("QT_VERSION")
@@ -125,7 +125,7 @@ def Configure(bUserInstall=False):
 	else:
 		cmd=[sys.executable,"-m", "pip", "install"] + (["--user"] if bUserInstall else []) + ['numpy']
 		if VISUS_GUI:
-			cmd+=[f"PyQt5~={QT_MAJOR_VERSION}.{QT_MINOR_VERSION}.0", f"PyQtWebEngine~={QT_MAJOR_VERSION}.{QT_MINOR_VERSION}.0", "PyQt5-sip"]
+			cmd+=[f"PyQt5=={QT_MAJOR_VERSION}.{QT_MINOR_VERSION}.0", f"PyQtWebEngine=={QT_MAJOR_VERSION}.{QT_MINOR_VERSION}.0", "PyQt5-sip"] # set to == to prevent qt version mismatch on mac install
 		ExecuteCommand(cmd, check_result=False) # False since it fails a lot !
 		
 	# *** fix rpath ****

--- a/Libs/swig/__main__.py
+++ b/Libs/swig/__main__.py
@@ -105,7 +105,7 @@ def ShowDeps(all_bins):
 # ////////////////////////////////////////////////
 def Configure(bUserInstall=False):
 	
-	IS_CONDA = False # os.path.exists(os.path.join(sys.prefix, 'conda-meta', 'history')) # see https://stackoverflow.com/questions/47608532/how-to-detect-from-within-python-whether-packages-are-managed-with-conda
+	IS_CONDA = True if "USE_CONDA" in os.environ and os.environ["USE_CONDA"] == "1" else False # os.path.exists(os.path.join(sys.prefix, 'conda-meta', 'history')) # see https://stackoverflow.com/questions/47608532/how-to-detect-from-within-python-whether-packages-are-managed-with-conda
 	IS_CPYTHON = not IS_CONDA
 	CONDA_PREFIX=os.environ['CONDA_PREFIX'] if IS_CONDA else ""		
 	VISUS_GUI=os.path.isfile("QT_VERSION")

--- a/docs/conda_installation.md
+++ b/docs/conda_installation.md
@@ -20,7 +20,7 @@ bash Anaconda3-2019.03-Linux-x86_64.sh
 conda config --set auto_activate_base false
 ```
 
-The activate conda:
+Then activate conda:
 
 ```
 conda activate
@@ -44,14 +44,15 @@ conda install --name myenv  -y --channel visus openvisus
 ```
 
 Test it (just ignore segmentation fault error on some Linux distributions in the `configure` step):
-
+If you would like to use conda for the rest of the configuration, create an environment variable: `USE_CONDA=1`
+Otherwise, by default, the configuration process will use pip.
 
 ```
 python -m OpenVisus configure 
 python -c "from OpenVisus import *"
 ```
 
-(OPTIONAL ) if you get *numpy import error* such as  `Library not loaded: @rpath/libopenblas.dylib`,  this:
+(OPTIONAL) If you get *numpy import error* such as  `Library not loaded: @rpath/libopenblas.dylib`,  this:
 
 ```
 conda uninstall --name myenv  -y numpy


### PR DESCRIPTION
Configuration of OpenViSUS through pip is much more stable compared to conda.

In my experimentation (on both Windows and macOS), configuration through pip allows the configuration script to find the qt5 library easily, so I propose to disable configuration through conda and handle all package installations through pip.

Additionally, not using `conda.cli.main` during installation will allow a user to create a plain conda python environment.

So instead of:
```
conda create -n myenv python=3.7 
conda activate myenv
conda install --name myenv  -y conda
pip install OpenVisus
python3 -m OpenVisus configure
python3 -m OpenVisus viewer
```

Installation for a user with conda would look like:
```
conda create -n myenv python=3.7 
conda activate myenv
pip install OpenVisus
python3 -m OpenVisus configure
python3 -m OpenVisus viewer
```

This change wouldn't affect users who run the configuration through Python without conda.