### PR TITLE
Prevent circleci from running on `gh-pages` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ workflows:
   build-and-deploy:
     jobs:
       - build-openvisus-arm64:
+          filters:
+            branches:
+              ignore: gh-pages
           matrix:
             parameters:
               python-version: ['3.7', '3.8', '3.9' ,'3.10' ]


### PR DESCRIPTION
Since the `gh-pages` branch is independent of `main`, circle ci jobs aren't needed. The `gh-pages` branch is handled through its own CI pipeline.